### PR TITLE
Add train model pipeline

### DIFF
--- a/.github/workflows/train_model.yml
+++ b/.github/workflows/train_model.yml
@@ -1,0 +1,29 @@
+name: Train Model
+
+on:
+    push:
+        branches:
+            - master
+
+jobs:
+    build-linux:
+        runs-on: ubuntu-latest
+        strategy:
+            max-parallel: 1
+        steps:
+            - uses: actions/checkout@v4
+            - name: Set up Python 3.12
+              uses: actions/setup-python@v3
+              with:
+                python-version: '3.12'
+            - name: Add conda to system path
+              run: |
+                # $CONDA is an environment variable pointing to the root of the miniconda directory
+                echo $CONDA/bin >> $GITHUB_PATH
+            - name: Install dependencies
+              run: |
+                conda env update --file environment.yml --name base
+            - name: Run training script
+              run: |
+                cd src
+                python main.py


### PR DESCRIPTION
This PR includes :
 - Adding a pipeline that is launched after pushing a commit on master branch to run a script that loads preprocessed data and train the model with it to automate model training 
 (can be optimized to do so only if the data/processed files changes)